### PR TITLE
bump mapbox library versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
 <meta property="og:image:height" content="636" />
 <meta property="og:image:alt" content="A polar histogram of road orientations in New York" />
 
-<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.css' rel='stylesheet' />
+<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.47.0-beta.1/mapbox-gl.js'></script>
+<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.47.0-beta.1/mapbox-gl.css' rel='stylesheet' />
 
-<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.2.0/mapbox-gl-geocoder.min.js'></script>
-<link href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.2.0/mapbox-gl-geocoder.css' rel='stylesheet' />
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.3.0/mapbox-gl-geocoder.min.js'></script>
+<link href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.3.0/mapbox-gl-geocoder.css' rel='stylesheet' />
 
 <script src='https://unpkg.com/cheap-ruler@2.5.1/cheap-ruler.js'></script>
 <script src='https://bundle.run/lineclip@1.1.5'></script>


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-js/releases/tag/v0.47.0-beta.1 contains a fix for https://github.com/mapbox/mapbox-gl-js/pull/6636. Without this, the search is broken on Android.